### PR TITLE
Add ostruct gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'activesupport'
 gem 'rake'
 
 gem "opsgenie-schedule", "~> 0.1.4"
+
+gem "ostruct", "~> 0.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       bigdecimal (~> 3.1)
     opsgenie-schedule (0.1.6)
       httparty (~> 0.17)
+    ostruct (0.6.1)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -118,6 +119,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-linux
 
@@ -127,6 +129,7 @@ DEPENDENCIES
   dotenv
   httparty
   opsgenie-schedule (~> 0.1.4)
+  ostruct (~> 0.6.1)
   pry
   rake
   rspec


### PR DESCRIPTION
Silence the warning about ostruct being removed from the default gems in Ruby
3.5.0 by adding it to the Gemfile.
```
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```